### PR TITLE
Replace adding system path syntax

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -28,7 +28,7 @@ jobs:
             https://github.com/x-motemen/blogsync/releases/download/${BLOGSYNC_VER}/blogsync_${BLOGSYNC_VER}_linux_amd64.tar.gz
           tar zxf blogsync.tar.gz -C bin --strip-component 1 blogsync_${BLOGSYNC_VER}_linux_amd64/blogsync
       - name: append blogsync path to PATH
-        run: echo "::add-path::./bin"
+        run: echo "./bin" >> $GITHUB_PATH
       - name: post entries
         env:
           TZ: "Asia/Tokyo"


### PR DESCRIPTION
I read your blog (https://kiririmode.hatenablog.jp/entry/20200104/1578094805) and set same setting to my blog. Then I found error log on GitHub Actions like

```
The `add-path` command is deprecated and will be disabled on MONTH DATE.
Please upgrade to using Environment Files.
For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

I refer https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path and it works. 

Could you check this?